### PR TITLE
Fix bug when batch_size > dataset size

### DIFF
--- a/sknn/backend/lasagne/mlp.py
+++ b/sknn/backend/lasagne/mlp.py
@@ -252,7 +252,7 @@ class MultiLayerPerceptronBackend(BaseBackend):
         if shuffle:
             numpy.random.shuffle(indices)
 
-        for start_idx in range(0, total_size - batch_size + 1, batch_size):
+        for start_idx in range(0, total_size, batch_size):
             excerpt = indices[start_idx:start_idx + batch_size]
             Xb, yb, wb = cast(X[excerpt]), cast(y[excerpt]), None
             if w is not None:


### PR DESCRIPTION
If batch size is greater than the total size of the data set, no data will be yielded from _iterate_data.  Consequently, no training will happen and you will get a ZeroDivision error for "loss / count" in _batch_impl.  Also, it only generates batches of the exact size - any remaining data at the end is not trained on.
